### PR TITLE
Fix zoxide cd wrapper history behavior

### DIFF
--- a/conf.d/cd.fish
+++ b/conf.d/cd.fish
@@ -1,8 +1,14 @@
+functions -c cd __original_cd
+
+function cd --wraps=zd --description 'alias cd=zd'
+  zd $argv
+end
+
 function zd --description 'zoxide-backed cd'
   if test (count $argv) -eq 0
-      builtin cd ~; and return
+      __original_cd ~; and return
   else if test -d $argv[1]
-      builtin cd -- $argv[1]
+      __original_cd -- $argv[1]
   else
       z $argv; and printf "\U000F17A9 "; and pwd || echo "Error: Directory not found"
   end

--- a/functions/cd.fish
+++ b/functions/cd.fish
@@ -1,3 +1,0 @@
-function cd --wraps=zd --description 'alias cd=zd'
-  zd $argv
-end


### PR DESCRIPTION
# Summary
- Fix zoxide cd wrapper breaking fish directory history (prevd) by using the preserved original cd instead of builtin cd.
- Move cd/zd definitions from functions/ to conf.d to preserve original cd before override and centralize related startup logic in a single file instead of splitting across autoload and config layers.