### PR TITLE
Quattro bash parity: herdr/ssh helpers, agent shortcuts, cx/ff/envs, try init, args completion

### DIFF
--- a/completions/omarchy.fish
+++ b/completions/omarchy.fish
@@ -1,48 +1,132 @@
 function __omarchy_complete
     set -l tokens (commandline -opc)
+    set -l words $tokens[2..-1]
 
     set -l omarchy_path (command -v omarchy 2>/dev/null); or return 0
     set -l resolved (realpath -- $omarchy_path 2>/dev/null); or set resolved $omarchy_path
     set -l bin_dir (dirname -- $resolved)
     test -d $bin_dir; or return 0
 
+    # Prefix from all words before the current token
     set -l prefix omarchy
-    set -l positional_count 0
-    for tok in $tokens[2..]
+    for tok in $words
         test -z "$tok"; and continue
         string match -q -- '-*' $tok; and continue
         set prefix $prefix-$tok
-        set positional_count (math $positional_count + 1)
     end
 
-    set -l seen
+    # Next-level subcommand candidates
+    set -l candidates
     for file in $bin_dir/$prefix-*
         test -f $file -a -x $file; or continue
         set -l basename (string replace -r '^.*/' '' -- $file)
         set -l rest (string replace -- $prefix- '' $basename)
         set -l next (string split -m 1 -- - $rest)[1]
         test -n "$next"; or continue
-        contains -- $next $seen; and continue
-        set -a seen $next
-        echo $next
+        contains -- $next $candidates; and continue
+        set -a candidates $next
     end
 
-    if test $positional_count -eq 0
-        echo commands
-        set -a seen commands
+    if test (count $words) -eq 0
+        contains -- commands $candidates; or set -a candidates commands
     end
 
-    if test (count $tokens) -ge 2 -a "$tokens[2]" = commands
-        echo --all
-        echo --json
-        echo --markdown
-        echo --check
-        set -a seen --all
+    if test (count $words) -ge 1 -a "$words[1]" = commands
+        set -a candidates --all --json --markdown --check
     end
 
-    if test -x $bin_dir/$prefix -o (count $seen) -gt 0
-        echo --help
+    if test (count $candidates) -eq 0
+        # Resolve the deepest omarchy-* command file from the typed words
+        set -l command_path
+        set -l n (count $words)
+        while test $n -ge 0
+            set -l command_prefix omarchy
+            if test $n -ge 1
+                for tok in $words[1..$n]
+                    test -z "$tok"; and continue
+                    string match -q -- '-*' $tok; and continue
+                    set command_prefix $command_prefix-$tok
+                end
+            end
+            if test -x $bin_dir/$command_prefix
+                set command_path $bin_dir/$command_prefix
+                break
+            end
+            set n (math $n - 1)
+        end
+
+        if test -n "$command_path"
+            set -l args (grep -m 1 '^# omarchy:args=' $command_path 2>/dev/null)
+            set -l argspec (string replace -r '^.*omarchy:args=' '' -- $args)
+
+            # Words after the resolved command are its arguments
+            set -l typed_args
+            if test (count $words) -gt $n
+                set typed_args $words[(math $n + 1)..-1]
+            end
+
+            # Alternatives are separated by ' | ', tokens by spaces
+            for alt in (string split ' | ' -- $argspec)
+                set -l spec (string split -n ' ' -- $alt)
+                set -l match true
+
+                for i in (seq (count $typed_args))
+                    set -l token
+                    if test $i -le (count $spec)
+                        set token $spec[$i]
+                    end
+                    if test -z "$token"
+                        set match false
+                        break
+                    end
+                    if string match -qr '^(<.*>|\[.*\])$' -- $token
+                        set -l value (string replace -r '^[<[]' '' -- $token | string replace -r '[>\]]$' '')
+                        if string match -q '*|*' -- $value
+                            if not contains -- $typed_args[$i] (string split '|' -- $value)
+                                set match false
+                                break
+                            end
+                        end
+                    else if test "$token" != "$typed_args[$i]"
+                        set match false
+                        break
+                    end
+                end
+                test $match = true; or continue
+
+                set -l k (math (count $typed_args) + 1)
+                set -l token
+                if test $k -le (count $spec)
+                    set token $spec[$k]
+                end
+                test -n "$token"; or continue
+
+                if string match -qr '^(<.*>|\[.*\])$' -- $token
+                    set -l value (string replace -r '^[<[]' '' -- $token | string replace -r '[>\]]$' '')
+                    if string match -q '*|*' -- $value
+                        for v in (string split '|' -- $value)
+                            contains -- $v $candidates; and continue
+                            set -a candidates $v
+                        end
+                    end
+                else
+                    contains -- $token $candidates; or set -a candidates $token
+                end
+            end
+        end
+    end
+
+    if test (count $candidates) -gt 0
+        printf '%s\n' $candidates
     end
 end
 
-complete -c omarchy -f -a '(__omarchy_complete)'
+function __omarchy_complete_has_candidates
+    set -l candidates (__omarchy_complete)
+    test (count $candidates) -gt 0
+end
+
+# Suppress file completion only when there are spec/subcommand candidates,
+# so free-form <tokens> fall back to file completion like bash's -o default.
+complete -c omarchy -n __omarchy_complete_has_candidates -f
+complete -c omarchy -a '(__omarchy_complete)'

--- a/conf.d/cd.fish
+++ b/conf.d/cd.fish
@@ -1,8 +1,14 @@
+functions -c cd __original_cd
+
+function cd --wraps=zd --description 'alias cd=zd'
+  zd $argv
+end
+
 function zd --description 'zoxide-backed cd'
   if test (count $argv) -eq 0
-      builtin cd ~; and return
+      __original_cd ~; and return
   else if test -d $argv[1]
-      builtin cd -- $argv[1]
+      __original_cd -- $argv[1]
   else
       z $argv; and printf "\U000F17A9 "; and pwd || echo "Error: Directory not found"
   end

--- a/conf.d/envs.fish
+++ b/conf.d/envs.fish
@@ -14,3 +14,8 @@ set -gx fzf_history_opts
 # Color man pages with bat
 set -x MANROFFOPT -c
 set -x MANPAGER "sh -c 'col -bx | bat -l man -p'"
+
+# Append ~/.local/bin to PATH if missing
+if not contains -- $HOME/.local/bin $PATH
+    set -gx PATH $PATH $HOME/.local/bin
+end

--- a/functions/_herdr_ratio.fish
+++ b/functions/_herdr_ratio.fish
@@ -1,0 +1,3 @@
+function _herdr_ratio --description 'Echo a split ratio as a float'
+    awk -v a="$argv[1]" -v b="$argv[2]" 'BEGIN { printf "%.4f", a / b }'
+end

--- a/functions/_herdr_split.fish
+++ b/functions/_herdr_split.fish
@@ -1,0 +1,4 @@
+function _herdr_split --description 'Split a herdr pane and echo the id of the new pane'
+    herdr pane split $argv[1] --direction $argv[2] --ratio $argv[3] --cwd $argv[4] --no-focus |
+        jq -r '.result.pane.pane_id'
+end

--- a/functions/_ssh_disarm.fish
+++ b/functions/_ssh_disarm.fish
@@ -1,0 +1,6 @@
+# Disarm mouse tracking (1000/1002/1003, 1006 encoding), focus reporting
+# (1004), and the alternate screen (1049), and show the cursor again. The
+# escapes are expanded by printf itself, so they stay single-quoted.
+function _ssh_disarm --description 'Disarm terminal modes armed over an ssh session'
+    printf '\e[?1000l\e[?1002l\e[?1003l\e[?1006l\e[?1004l\e[?1049l\e[?25h'
+end

--- a/functions/_ssh_interactive.fish
+++ b/functions/_ssh_interactive.fish
@@ -1,0 +1,49 @@
+# True for an interactive session: a destination and no remote command. The
+# letters are the ssh(1) options that consume a value, so their arguments are
+# not mistaken for the destination.
+function _ssh_interactive --description 'Test whether an ssh invocation opens an interactive session'
+    set -l value_opts BbcDEeFIiJLlmOoPpQRSWw
+    set -l invocation $argv
+    set -l dest ""
+    set -l opts_done false
+
+    while set -q argv[1]
+        set -l arg $argv[1]
+        set -e argv[1]
+
+        if test $opts_done = false; and test "$arg" = "--"
+            set opts_done true
+        else if test $opts_done = false; and string match -qr -- '^-.+' $arg
+            set -l letters (string split '' -- (string replace -r '^-' '' -- $arg))
+            set -l i 1
+            set -l n (count $letters)
+            while test $i -le $n
+                if string match -q -- "*$letters[$i]*" $value_opts
+                    # The value is glued to the letter (-p2222) unless the
+                    # letter ends the argument, in which case it consumes
+                    # the next one (-p 2222).
+                    if test $i -eq $n; and set -q argv[1]
+                        set -e argv[1]
+                    end
+                    break
+                end
+                set i (math "$i + 1")
+            end
+        else if test -z "$dest"
+            set dest $arg
+        else
+            return 1
+        end
+    end
+
+    test -n "$dest"; or return 1
+
+    # A RemoteCommand from ssh_config or -o replays on reconnect just like a
+    # positional command; ssh -G resolves the effective configuration for this
+    # exact invocation without connecting. Fail closed when it cannot resolve,
+    # since an undetected RemoteCommand must not replay. The explicit "none"
+    # cancels a configured command, and some versions emit it when unset.
+    set -l resolved (command ssh -G $invocation 2>/dev/null); or return 1
+    set -l commands (string match -ri '^remotecommand ' -- $resolved | string match -vi -- '^remotecommand none$')
+    test (count $commands) -eq 0
+end

--- a/functions/a.fish
+++ b/functions/a.fish
@@ -1,0 +1,3 @@
+function a --wraps=omarchy-agent --description 'Launch the default coding agent inline'
+    omarchy-agent --inline $argv
+end

--- a/functions/c.fish
+++ b/functions/c.fish
@@ -1,3 +1,3 @@
-function c --wraps=opencode --description 'alias c=opencode'
-  opencode $argv
+function c --wraps=opencode --description 'alias c=opencode --auto'
+  opencode --auto $argv
 end

--- a/functions/cd.fish
+++ b/functions/cd.fish
@@ -1,3 +1,0 @@
-function cd --wraps=zd --description 'alias cd=zd'
-  zd $argv
-end

--- a/functions/cx.fish
+++ b/functions/cx.fish
@@ -1,4 +1,4 @@
-function cx --description 'Launch Claude Code with Dangerously Skip Permissions Allowed'
+function cx --description 'Launch Claude Code with bypassPermissions mode'
     printf "\033[2J\033[3J\033[H"
-    claude --allow-dangerously-skip-permissions $argv
+    claude --permission-mode bypassPermissions $argv
 end

--- a/functions/cx.fish
+++ b/functions/cx.fish
@@ -1,4 +1,4 @@
-function cx --description 'Launch Claude Code with bypassPermissions mode'
+function cx --description 'Launch Claude Code with auto permission mode'
     printf "\033[2J\033[3J\033[H"
-    claude --permission-mode bypassPermissions $argv
+    claude --permission-mode auto $argv
 end

--- a/functions/cy.fish
+++ b/functions/cy.fish
@@ -1,0 +1,3 @@
+function cy --description 'alias cy=codex -s danger-full-access -a never'
+    codex -s danger-full-access -a never $argv
+end

--- a/functions/cy.fish
+++ b/functions/cy.fish
@@ -1,3 +1,3 @@
-function cy --description 'alias cy=codex -s danger-full-access -a never'
-    codex -s danger-full-access -a never $argv
+function cy --description 'alias cy=codex --approve-for-me'
+    codex --approve-for-me $argv
 end

--- a/functions/dsw.fish
+++ b/functions/dsw.fish
@@ -1,0 +1,12 @@
+function dsw --description 'Stop rsync-on-change watchers'
+    set -l found 0
+    for pid in (pgrep -f 'rsw-watch ')
+        if kill -- -$pid 2>/dev/null
+            echo "Stopped watch (pid $pid)"
+            set found 1
+        end
+    end
+    if test $found -eq 0
+        echo "No active watches"
+    end
+end

--- a/functions/ff.fish
+++ b/functions/ff.fish
@@ -1,3 +1,7 @@
-function ff --wraps="fzf --preview 'bat --style=numbers --color=always {}'" --description "alias ff=fzf --preview 'bat --style=numbers --color=always {}'"
-  fzf --preview 'bat --style=numbers --color=always {}' $argv
+function ff --wraps=fzf --description 'fzf with bat preview; kitty icat for images under xterm-kitty'
+    if test "$TERM" = xterm-kitty
+        fzf --preview 'if string match -q "image/*" -- (file --mime-type -b {}); kitty icat --clear --transfer-mode=memory --stdin=no --place={$FZF_PREVIEW_COLUMNS}x{$FZF_PREVIEW_LINES}@0x0 {}; else; bat --style=numbers --color=always {}; end' $argv
+    else
+        fzf --preview 'bat --style=numbers --color=always {}' $argv
+    end
 end

--- a/functions/ff.fish
+++ b/functions/ff.fish
@@ -1,6 +1,9 @@
 function ff --wraps=fzf --description 'fzf with bat preview; kitty icat for images under xterm-kitty'
     if test "$TERM" = xterm-kitty
-        fzf --preview 'if string match -q "image/*" -- (file --mime-type -b {}); kitty icat --clear --transfer-mode=memory --stdin=no --place={$FZF_PREVIEW_COLUMNS}x{$FZF_PREVIEW_LINES}@0x0 {}; else; bat --style=numbers --color=always {}; end' $argv
+        # fzf runs the preview script via $SHELL, which the bash->fish
+        # trampoline leaves pointing at bash — pin fish for this call so
+        # the fish syntax in the preview actually parses.
+        SHELL=(command -v fish) fzf --preview 'if string match -q "image/*" -- (file --mime-type -b {}); kitty icat --clear --transfer-mode=memory --stdin=no --place={$FZF_PREVIEW_COLUMNS}x{$FZF_PREVIEW_LINES}@0x0 {}; else; bat --style=numbers --color=always {}; end' $argv
     else
         fzf --preview 'bat --style=numbers --color=always {}' $argv
     end

--- a/functions/h.fish
+++ b/functions/h.fish
@@ -1,0 +1,3 @@
+function h --wraps=herdr --description 'alias h=herdr'
+    herdr $argv
+end

--- a/functions/hdl.fish
+++ b/functions/hdl.fish
@@ -1,0 +1,40 @@
+# Create a Herdr Dev Layout with editor, ai, and terminal
+# Usage: hdl <c|cx|codex|other_ai> [<second_ai>]
+function hdl
+    if test -z "$argv[1]"
+        echo "Usage: hdl <c|cx|codex|other_ai> [<second_ai>]"
+        return 1
+    end
+    if test -z "$HERDR_PANE_ID"
+        echo "You must start herdr to use hdl."
+        return 1
+    end
+
+    set -l current_dir (pwd)
+    set -l ai $argv[1]
+    set -l ai2 $argv[2]
+
+    # Use HERDR_PANE_ID for the pane we're running in (stable even if focus moves)
+    set -l editor_pane $HERDR_PANE_ID
+
+    # Name the current tab after the base directory name
+    herdr tab rename $HERDR_TAB_ID (basename $current_dir) >/dev/null
+
+    # Split tab vertically - top 85%, bottom 15%
+    _herdr_split $editor_pane down 0.85 $current_dir >/dev/null
+
+    # Split editor pane horizontally - AI on right 30%
+    set -l ai_pane (_herdr_split $editor_pane right 0.7 $current_dir)
+
+    # If second AI provided, split the AI pane vertically
+    if test -n "$ai2"
+        set -l ai2_pane (_herdr_split $ai_pane down 0.5 $current_dir)
+        herdr pane run $ai2_pane $ai2 >/dev/null
+    end
+
+    # Run ai in the right pane
+    herdr pane run $ai_pane $ai >/dev/null
+
+    # Run the editor in the left pane
+    herdr pane run $editor_pane "$EDITOR ." >/dev/null
+end

--- a/functions/hdlm.fish
+++ b/functions/hdlm.fish
@@ -1,0 +1,40 @@
+# Create multiple hdl tabs with one per subdirectory in the current directory
+# Usage: hdlm <c|cx|codex|other_ai> [<second_ai>]
+function hdlm
+    if test -z "$argv[1]"
+        echo "Usage: hdlm <c|cx|codex|other_ai> [<second_ai>]"
+        return 1
+    end
+    if test -z "$HERDR_PANE_ID"
+        echo "You must start herdr to use hdlm."
+        return 1
+    end
+
+    set -l ai $argv[1]
+    set -l ai2 $argv[2]
+    set -l base_dir (pwd)
+    set -l first true
+
+    # Rename the workspace to the current directory name
+    herdr workspace rename $HERDR_WORKSPACE_ID (basename $base_dir) >/dev/null
+
+    for dir in $base_dir/*/
+        test -d $dir; or continue
+        set -l dirpath (string replace -r '/$' '' -- $dir)
+
+        set -l hdl_command "hdl "(string escape -- $ai)
+        if test -n "$ai2"
+            set hdl_command "$hdl_command "(string escape -- $ai2)
+        end
+
+        if test $first = true
+            # Reuse the current tab for the first project
+            herdr pane run $HERDR_PANE_ID "cd "(string escape -- $dirpath)" && $hdl_command" >/dev/null
+            set first false
+        else
+            set -l pane_id (herdr tab create --workspace $HERDR_WORKSPACE_ID --cwd $dirpath --no-focus |
+                jq -r '.result.root_pane.pane_id')
+            herdr pane run $pane_id "$hdl_command" >/dev/null
+        end
+    end
+end

--- a/functions/hds.fish
+++ b/functions/hds.fish
@@ -1,0 +1,26 @@
+# Create a Herdr Dev Square layout with editor, diff watch, terminal, and opencode
+# Usage: hds
+function hds
+    if test -n "$argv[1]"
+        echo "Usage: hds"
+        return 1
+    end
+    if test -z "$HERDR_PANE_ID"
+        echo "You must start herdr to use hds."
+        return 1
+    end
+
+    set -l current_dir (pwd)
+
+    set -l editor_pane $HERDR_PANE_ID
+
+    herdr tab rename $HERDR_TAB_ID (basename $current_dir) >/dev/null
+
+    set -l terminal_pane (_herdr_split $editor_pane down 0.5 $current_dir)
+    set -l diff_pane (_herdr_split $editor_pane right 0.5 $current_dir)
+    set -l opencode_pane (_herdr_split $terminal_pane right 0.5 $current_dir)
+
+    herdr pane run $editor_pane "nvim ." >/dev/null
+    herdr pane run $diff_pane "hunk diff --watch" >/dev/null
+    herdr pane run $opencode_pane "opencode" >/dev/null
+end

--- a/functions/hsl.fish
+++ b/functions/hsl.fish
@@ -1,0 +1,53 @@
+# Create a multi-pane swarm layout with the same command started in each pane (great for AI)
+# Usage: hsl <pane_count> <command>
+function hsl
+    if test -z "$argv[1]" -o -z "$argv[2]"
+        echo "Usage: hsl <pane_count> <command>"
+        return 1
+    end
+    if test -z "$HERDR_PANE_ID"
+        echo "You must start herdr to use hsl."
+        return 1
+    end
+
+    set -l count $argv[1]
+    set -l cmd $argv[2]
+    set -l current_dir (pwd)
+    set -l columns
+    set -l panes
+
+    herdr tab rename $HERDR_TAB_ID (basename $current_dir) >/dev/null
+
+    # Tile into a grid: ceil(sqrt(count)) columns, rows spread across them
+    set -l cols 1
+    while test (math "$cols * $cols") -lt $count
+        set cols (math "$cols + 1")
+    end
+
+    # Even columns come from splitting the rightmost one off at 1/(n-k+1) each time,
+    # which keeps the array in left-to-right order
+    set -a columns $HERDR_PANE_ID
+    for k in (seq 1 (math "$cols - 1"))
+        set -a columns (_herdr_split $columns[-1] right (_herdr_ratio 1 (math "$cols - $k + 1")) $current_dir)
+    end
+
+    # Split each column into its share of rows, again evenly and top-to-bottom
+    set -l index 0
+    for col in $columns
+        set -l rows (math -s0 "$count / $cols")
+        if test $index -lt (math "$count % $cols")
+            set rows (math "$rows + 1")
+        end
+        set -a panes $col
+        set -l last $col
+        for j in (seq 1 (math "$rows - 1"))
+            set last (_herdr_split $last down (_herdr_ratio 1 (math "$rows - $j + 1")) $current_dir)
+            set -a panes $last
+        end
+        set index (math "$index + 1")
+    end
+
+    for pane in $panes
+        herdr pane run $pane "$cmd" >/dev/null
+    end
+end

--- a/functions/lsw.fish
+++ b/functions/lsw.fish
@@ -1,0 +1,14 @@
+function lsw --description 'List rsync-on-change watchers'
+    set -l found 0
+    for line in (pgrep -af 'rsw-watch ')
+        set -l pid (string split -m 1 ' ' -- $line)[1]
+        set -l rest (string replace -r '^.*rsw-watch ' '' -- $line)
+        set -l src (string replace -r ' [^ ]*$' '' -- $rest)
+        set -l dest (string replace -r '^.* ' '' -- $rest)
+        echo "$pid: $src -> $dest"
+        set found 1
+    end
+    if test $found -eq 0
+        echo "No active watches"
+    end
+end

--- a/functions/mup.fish
+++ b/functions/mup.fish
@@ -1,3 +1,3 @@
-function mup --description 'alias mup=MISE_MINIMUM_RELEASE_AGE=0 mise up'
+function mup --wraps='mise up' --description 'alias mup=MISE_MINIMUM_RELEASE_AGE=0 mise up'
     MISE_MINIMUM_RELEASE_AGE=0 mise up $argv
 end

--- a/functions/mup.fish
+++ b/functions/mup.fish
@@ -1,0 +1,3 @@
+function mup --description 'alias mup=MISE_MINIMUM_RELEASE_AGE=0 mise up'
+    MISE_MINIMUM_RELEASE_AGE=0 mise up $argv
+end

--- a/functions/rsw.fish
+++ b/functions/rsw.fish
@@ -1,0 +1,21 @@
+# Rsync-on-change watchers: rsw starts one in the background, lsw lists, dsw stops
+function rsw --description 'Start rsync-on-change watcher'
+    if test (count $argv) -ne 2
+        echo "Usage: rsw <source> <destination>"
+        return 1
+    end
+
+    set -l src (string replace -r '/$' '' -- $argv[1])
+    set -l dest $argv[2]
+
+    # Reuse one SSH connection per login, so 1Password only prompts once.
+    set -l sockets $HOME/.ssh/sockets
+    if set -q XDG_RUNTIME_DIR; and test -n "$XDG_RUNTIME_DIR"
+        set sockets $XDG_RUNTIME_DIR
+    end
+    mkdir -p $sockets
+
+    set -l rsh "ssh -o ControlMaster=auto -o ControlPath=$sockets/rsw-%r@%h:%p -o ControlPersist=yes"
+    setsid --fork env RSYNC_RSH="$rsh" bash -c 'rsync -a "$1/" "$2"; while inotifywait -r -q -e modify,create,delete,move "$1"; do rsync -a "$1/" "$2"; done' rsw-watch $src $dest >/dev/null 2>&1
+    echo "Watching $src -> $dest"
+end

--- a/functions/ssh.fish
+++ b/functions/ssh.fish
@@ -1,0 +1,39 @@
+# Wrap ssh to clean up the terminal and reconnect when a connection drops.
+#
+# A remote tmux, herdr, or editor arms terminal modes over the SSH pipe (mouse
+# tracking, focus reporting, the alternate screen) that only it can disarm. If
+# the connection dies instead of exiting cleanly, those modes stay armed on
+# the local terminal, and every mouse move floods the prompt with escape junk.
+function ssh --description 'ssh with terminal cleanup and auto-reconnect on dropped sessions'
+    set -l rc
+    set -l started (date +%s)
+
+    command ssh $argv
+    set rc $status
+
+    if not test -t 1
+        return $rc
+    end
+    _ssh_disarm
+
+    # Reconnect only when an interactive session drops: ssh exits 255 for
+    # transport failures, but a fast 255 with no established session is a
+    # connect/auth failure, a remote command's own 255 passes through
+    # indistinguishably and must not replay its side effects, and redirected
+    # stdin would feed the remaining piped input to a fresh remote shell.
+    if test $rc -ne 255; or not test -t 0; or not _ssh_interactive $argv; or test (math "(date +%s) - $started") -lt 30
+        return $rc
+    end
+
+    # Ctrl-C cancels the whole function in fish (not just the running ssh),
+    # which is what the bash subshell loop achieved. Keep retrying fast
+    # failures, since a rebooting server refuses connections too.
+    while true
+        echo "Connection lost. Reconnecting (Ctrl-C to stop)..."
+        sleep 2
+        command ssh $argv
+        set rc $status
+        _ssh_disarm
+        test $rc -ne 255; and return $rc
+    end
+end

--- a/functions/tds.fish
+++ b/functions/tds.fish
@@ -1,0 +1,31 @@
+# Create a Tmux Dev Square layout with editor, diff watch, terminal, and opencode
+# Usage: tds
+function tds
+    if test (count $argv) -gt 0
+        echo "Usage: tds"
+        return 1
+    end
+
+    if not tmux display-message -p -t $TMUX_PANE &>/dev/null
+        echo "You must start tmux to use tds."
+        return 1
+    end
+
+    set -l current_dir (pwd)
+    set -l editor_pane $TMUX_PANE
+
+    tmux rename-window -t $editor_pane (basename $current_dir)
+
+    set -l terminal_pane (tmux split-window -v -p 50 -t $editor_pane -c $current_dir -P -F '#{pane_id}')
+    set -l diff_pane (tmux split-window -h -p 50 -t $editor_pane -c $current_dir -P -F '#{pane_id}')
+    set -l opencode_pane (tmux split-window -h -p 50 -t $terminal_pane -c $current_dir -P -F '#{pane_id}')
+
+    tmux send-keys -t $editor_pane -l "nvim ."
+    tmux send-keys -t $editor_pane C-m
+    tmux send-keys -t $diff_pane -l "hunk diff --watch"
+    tmux send-keys -t $diff_pane C-m
+    tmux send-keys -t $opencode_pane -l "opencode"
+    tmux send-keys -t $opencode_pane C-m
+
+    tmux select-pane -t $editor_pane
+end

--- a/functions/try.fish
+++ b/functions/try.fish
@@ -1,32 +1,9 @@
-# Define try function manually to fix Fish shell compatibility issues
-# Solves issues addressed in open PR: https://github.com/tobi/try/pull/39
-function try
-    set -l script_path "/usr/bin/try"
-
-    if not test -x "$script_path"
-        echo "Error: 'try' command not found."
-        echo "Please install it with: sudo pacman -S tobi-try"
-        return 1
-    end
-
-    set -l tries_path ~/Work/tries
-
-    set -l cmd
-    switch "$argv[1]"
-        case clone worktree init
-            set cmd (/usr/bin/env ruby "$script_path" --path "$tries_path" $argv 2>/dev/tty | string collect)
-        case '*'
-            set cmd (/usr/bin/env ruby "$script_path" cd --path "$tries_path" $argv 2>/dev/tty | string collect)
-    end
-    set -l rc $status
-
-    if test $rc -eq 0
-        if string match -q "*try something!*" -- $cmd
-            printf "%s\n" $cmd
-        else
-            eval $cmd
-        end
-    else
-        printf "%s\n" $cmd
+# Lazy-load try shell integration on first use, mirroring bash init.
+# try init emits a fish function when SHELL points at fish.
+if command -q try
+    function try --description 'Lazy-load try shell integration'
+        functions -e try
+        SHELL=(command -v fish) command try init ~/Work/tries | source
+        try $argv
     end
 end


### PR DESCRIPTION
Brings the fish profile to parity with the Omarchy Quattro bash profile (`default/bash/` in basecamp/omarchy, quattro branch). Downstream context: omarchy-nix pins omarchy-fish; this also unblocks restoring `try.fish` there, where the hard-coded `/usr/bin/try` + `/usr/bin/env ruby` wrapper doesn't fit.

**New functions**

- `a` — `omarchy-agent --inline` (default coding agent).
- `h` — `herdr`.
- `cy` — `codex --approve-for-me`.
- `mup` — `MISE_MINIMUM_RELEASE_AGE=0 mise up` (`default/bash/aliases:55`).
- `rsw` / `lsw` / `dsw` — rsync-on-change watchers (`default/bash/fns/rsyncing`). Same semantics: detached `setsid --fork` watcher with the `rsw-watch` argv0 marker, `pgrep -af` listing, process-group kill on stop.
- `tds` — tmux dev square layout (`default/bash/fns/tmux:42-65`), mirroring `tdl.fish` conventions. Bash `tds` correctly selects `$editor_pane` at the end (unlike bash `tdl`, which selects an unset `$opencode_pane`; `tdl.fish` already fixed that), so no behavior fix was needed here.
- `hdl` / `hds` / `hdlm` / `hsl` — port of `default/bash/fns/herdr`, following the `tdl.fish`/`tds.fish` conventions:
  - `hdl <ai> [<second_ai>]` — 85/15 vertical split, AI on the right 30%, optional second AI stacked under it, `$EDITOR .` in the editor pane.
  - `hds` — 2x2 square: editor / `hunk diff --watch` / terminal / `opencode`.
  - `hdlm <ai> [<second_ai>]` — one `hdl` tab per subdirectory; the first project reuses the current tab, the workspace is renamed to the base directory.
  - `hsl <count> <command>` — swarm grid of identical panes: `ceil(sqrt(count))` columns split evenly, rows distributed top-to-bottom, the command started in every pane.
  - `_herdr_ratio` / `_herdr_split` ship as the shared plumbing.
- `ssh` + `_ssh_disarm` + `_ssh_interactive` — port of `default/bash/fns/ssh-reconnect`: disarm mouse-tracking/focus/alt-screen modes on exit, reconnect only when an interactive session drops (rc 255, tty stdin, ≥30 s elapsed, no `RemoteCommand` via `ssh -G` — fail closed), retry loop for transport failures.

**Agent-shortcut alignment**

`c`, `cx`, `cy` match Quattro's bash aliases as of 2026-08-15: `c` → `opencode --auto`, `cx` → `claude --permission-mode auto` (upstream moved from `bypassPermissions` to `auto` after this PR opened), `cy` → `codex --approve-for-me` (replacing `-s danger-full-access -a never`).

**Changes to existing files**

- `c.fish` — add `--auto`.
- `cx.fish` — `--permission-mode auto`, aligned with the 2026-08-15 aliases. Scrollback clear and `$argv` pass-through unchanged.
- `ff.fish` — add the `xterm-kitty` branch from `default/bash/aliases:9-13`: image previews via `kitty icat`, bat otherwise. fzf executes previews through `$SHELL`, which stays bash under Omarchy's `exec fish` trampoline (thanks @silouanwright for the reproduction) — the kitty branch pins `SHELL=(command -v fish)` for the fzf invocation so the fish-syntax preview parses. `$FZF_PREVIEW_COLUMNS`/`$FZF_PREVIEW_LINES` expand in the preview shell, as in bash.
- `conf.d/envs.fish` — append `~/.local/bin` to PATH if absent (`default/bash/envs:14-17`).
- `try.fish` — replace the hard-coded `/usr/bin/try` wrapper with a lazy init matching `default/bash/init:13-19`: first call erases itself, sources `try init ~/Work/tries` with `SHELL` forced to fish (upstream try has explicit fish support and emits a fish function), then delegates. Only defined when `try` is installed, matching the bash `command -v` guard.

**Completions**

- `completions/omarchy.fish` — port the `# omarchy:args=` contract from `default/bash/completions:43-117`: resolve the deepest `omarchy-*` command file from the typed words, parse its first `# omarchy:args=` line, match ` | `-separated alternatives against already-typed args (`<a|b>` restricts, `<id>` / `[opt]` are free-form), and offer the token at the current position. File completion is suppressed only when spec candidates exist, mirroring `complete -o default`: free-form tokens like `<theme-name>` fall back to file completion. The fish-only `--help` candidate from #5 is dropped — bash doesn't offer it, and keeping it would prevent the args-spec phase from ever running.

**Zoxide cd history**

- Includes the fix from open PR #6, cherry-picked with authorship preserved: `cd`/`zd` move to `conf.d/cd.fish` and call the preserved original `cd`, so fish's `dirprev`/`dirnext` history keeps working. Fish's stock `cd` is a function that maintains that history; `builtin cd` from `zd` bypassed it. No conflict with the bash `zd` semantics (`default/bash/aliases:19-33`), which has no such history mechanism. Supersedes #6 — thanks @abdulrahman-aj.

**Fish porting notes** (bash → fish deltas in the new ports)

- `$(( ))` integer division → `math -s0`.
- `$SECONDS` elapsed timing → `date +%s`.
- the bash retry subshell → a plain loop: Ctrl-C cancels the whole function in fish, which is the same outcome the subshell achieved.
- the bash `-?*` option-cluster glob test → `string match -qr '^-.+'` (`?` is not a wildcard in fish globs).
- `printf %q` quoting in `hdlm` → `string escape`.

**Testing**

- `fish -n` clean on all touched files.
- Completion output compared against bash `_omarchy_complete` on a fixture bin dir (symlinked `omarchy`, scripts with real spec lines): identical candidates for subcommand, args-spec, multi-alternative, restricted-value, and file-fallback cases.
- `rsw`/`lsw`/`dsw` exercised end-to-end with a stub `inotifywait`: initial sync, `pid: src -> dest` listing, process-group stop.
- `tds` run in a detached tmux server: 2x2 pane layout, usage and arg errors.
- `try` lazy init verified with a stub `try` binary (fish snippet emitted, self-erasure, delegation with args); without the binary the function stays undefined, like the bash guard.
- `ff` verified with a stub `fzf`: under `TERM=xterm-kitty` the invocation sees `SHELL` pointing at fish and the substituted preview script parses under fish; under other terminals nothing changes.
- herdr family stub-tested against a fake `herdr` (canned pane JSON + real `jq`): exact split sequences for `hdl` (85/15, AI at 30%, optional second AI), `hds` (2x2), `hdlm` (workspace rename, first project reuses the current pane, one tab per subdir), `hsl` (5 panes → 3 columns 2+2+1; 4 panes → 2x2), plus every usage/guard error path.
- ssh family: `_ssh_disarm` byte-exact via `od`; `_ssh_interactive` parser matrix (glued/separate option values, `--`, positional commands, missing option values, `RemoteCommand` via `ssh -G` including an explicit `none`); wrapper rc passthrough via a PATH stub, with no reconnect attempt absent a tty.
