### PR TITLE
Add mup function for fish parity with bash's mup alias

### DIFF
--- a/functions/mup.fish
+++ b/functions/mup.fish
@@ -1,0 +1,3 @@
+function mup --wraps='mise up' --description 'alias mup=MISE_MINIMUM_RELEASE_AGE=0 mise up'
+  MISE_MINIMUM_RELEASE_AGE=0 mise up $argv
+end


### PR DESCRIPTION
## Summary
- Omarchy's bash config defines `mup` as `MISE_MINIMUM_RELEASE_AGE=0 mise up`, letting `mup` fetch current mise tool releases immediately instead of waiting out mise's normal release-age cooldown.
- fish had no equivalent function, so `mup` was unavailable to fish users even though it's documented/used as a standard Omarchy shortcut.
- Adds `functions/mup.fish` following the existing wrapper-function pattern used by `gcm.fish` etc.

## Test plan
- [ ] `fish -c 'mup --help'` resolves to the new function (manually verified function loads and forwards args to `mise up`)